### PR TITLE
Hopefully corrected a maven coordinate.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [com.taoensso/timbre "4.10.0"]
                  [com.cognitect/transit-cljs "0.8.243"]
                  [binaryage/oops "0.5.8"]
-                 [parinfer-cljs "3.11.0-0"]
+                 [parinfer-cljs "1.5.1-0"]
                  [cljsjs/rangy-core "1.3.0-1"]
                  [cljsjs/rangy-textrange "1.3.0-1"]
                  [reagent "0.7.0"]


### PR DESCRIPTION
Hi,
I was unable to build the project using the instructions in the readme:

```
git clone git@github.com:raymcdermott/reptile-tongue.git
lein cljsbuild once min
Compiling ClojureScript...
Could not find artifact parinfer-cljs:parinfer-cljs:jar:3.11.0-0 in central (https://repo1.maven.org/maven2/)
Could not find artifact parinfer-cljs:parinfer-cljs:jar:3.11.0-0 in clojars (https://clojars.org/repo/)
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
```

Looking in clojars there is one artifact named `[cljsjs/parinfer "3.11.0-0"]` and one named `[parinfer-cljs "1.5.1-0"]` but none named `[parinfer-cljs "3.11.0-0"]`.

Replacing `[parinfer-cljs "3.11.0-0"]` with `[parinfer-cljs "1.5.1-0"]` made the project compile.